### PR TITLE
Add optional input parameter to decode command

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,15 +16,19 @@ export function activate(context: vscode.ExtensionContext) {
 	const xss = require('xss');
 
 	// Register commands
-	let command = vscode.commands.registerCommand('base64viewer.decodeBase64', () => {
-		vscode.window
-			.showInputBox({
-				prompt: messages.general.prompt.decode,
-			})
-			.then(
-				(base64String) => decodeAndDisplay(extensionRoot, xss(base64String)),
-				(reason) => showErrorPopup(reason),
-			);
+	let command = vscode.commands.registerCommand('base64viewer.decodeBase64', (base64Input?: string) => {
+		if (base64Input) {
+			decodeAndDisplay(extensionRoot, xss(base64Input));
+		} else {
+			vscode.window
+				.showInputBox({
+					prompt: messages.general.prompt.decode,
+				})
+				.then(
+					(base64String) => decodeAndDisplay(extensionRoot, xss(base64String)),
+					(reason) => showErrorPopup(reason),
+				);
+		}
 	});
 	context.subscriptions.push(command);
 


### PR DESCRIPTION
Adds an optional input parameter to the `base64viewer.decodeBase64` command, so it can be called from external extensions using
```typescript
vscode.commands.executeCommand('base64viewer.decodeBase64', 'some-base64-string');
```

The current behavior of calling the command via the command palette and then getting an input box remains the same.

Closes #20